### PR TITLE
Two tags query failed workaround

### DIFF
--- a/search-everything.php
+++ b/search-everything.php
@@ -516,7 +516,7 @@ class SearchEverything {
 				if ( $this->wp_ver23 ) {
 					$search .= "{$searchand}(tter.name LIKE '{$n}{$term}{$n}')";
 				}
-				$searchand = ' AND ';
+				$searchand = ' OR ';
 			}
 			$sentence_term = $wpdb->escape( $s );
 			if ( count( $search_terms ) > 1 && $search_terms[0] != $sentence_term ) {


### PR DESCRIPTION
If search hand is set to 'AND' and you search by tags, query sometimes fails to get any post with those tags.

Let me explain this phenomenon.

Example case: 'postA' tagged with both 'tagX' and 'tagY' names.

I made some re-engineering and I found out, that tags are left joined in the actual search query. It means, for query search our example case, mysql gets two rows:

tagName, postName
tagX, postA
tagY, postA

There is no row with 'tagX' AND 'tagY'. They are separated. You get in final result a single one, because of the distinct select mode.

To make it done as it should be done, all query should be rewritten to include either concatenated tag names, or some subquery to get post IDs by tag names.

There might be some performance problems and it need some time to test this or any other solution, but for now, there should be no 'AND' shorthand for tag names. 

Correct me if I'm wrong.
